### PR TITLE
Business model

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,10 +7,9 @@
 	- [Investors](/handbook/investors)
 	- People
 		- [Team](/handbook/team)
-		- [Time Off](/handbook/time-off.md)
+		- [Time Off](/handbook/time-off)
 	- [Strategy](/handbook/strategy)
+		- [Business Model](/handbook/business-model)
 - [Handbook](/handbook/using-the-handbook)
 - [Careers](/careers)
-- [Pricing](/pricing)
-- [Contact](/contact)
 - [Terms](/terms)

--- a/docs/handbook/business-model.md
+++ b/docs/handbook/business-model.md
@@ -1,0 +1,39 @@
+# Business Model
+
+PostHog is a for profit company that balances the need to improve the open source code of PostHog with the need to add source-available features in order to generate income. We will build an open core business model.
+
+## Why would you work on the Community Edition?
+
+A concern could be that given our business model, we'd only work on paid features.
+
+The reality is that paid features can increase our revenue, thus our ability to grow and hire more developers, who we will use on both versions of the product. When we work on the Community Edition, it increases the community size, which means we end up with more features, and thus a better product. This means we get yet more community growth and it also helps with revenue growth too since the source-available product will also improve.
+
+At the moment, 100% of our focus is on the Community Edition of the software.
+
+## Promises
+
+1. We won't introduce features into the open source codebase with a delay.
+1. We will always release and open source all tests we have for an open source feature.
+1. The open source codebase will never contain arbitrary limits (i.e. event volumes, user numbers).
+1. The majority of new features made by PostHog will remain open source.
+1. The product will always be available for download without leaving an email address or logging in.
+1. We will always allow you to [benchmark](https://news.ycombinator.com/item?id=18103162) PostHog.
+
+## What features are paid only?
+
+If the wider community contributes a new feature, that isn't already a source-available feature, we aim nearly always for it to go into the open source codebase.
+
+When PostHog makes a new feature, we ask ourselves two questions:
+
+1. Who is the likely type buyer of this feature?
+1. Would this feature help more users find and use PostHog?
+
+If the likely buyer is an individual contributor, the feature will be open source. Otherwise, if the likely buyer is a manager, director or executive, it will be source available. The exception to this is if the feature will significantly help the community to increase. For example, initially we planned "multiple users" as a feature for the source-available version. However, we decided that having multiple users would help the community to grow, which benefits everyone disproportionately.
+
+## How open source benefits from open core.
+
+1. PostHog contributes many new features to the open source version. Having a viable business model makes it easier for us to invest more here.
+1. Security fixes.
+1. Support until the community can self sustain itself.
+1. Performance improvements.
+1. Running an upgrade server.


### PR DESCRIPTION
I was tempted to add in addition the following, but think the timing is wrong:

```If the community submit a new feature, the author can choose if the code goes into the open source or source available codebase.```

The reason for doing this is inspired by [GitLab's policy on new features from their community](https://about.gitlab.com/company/stewardship/#contributing-a-not-yet-existing-feature). It'd encourage people to contribute "before" we get to certain areas of the product.

The only reason for *not* doing this was that we have a ton of functionality to build out now so it could cause us issues in a few months time with generating revenue in light of our current stage. I'd suggest this is a chance that we revisit in the future just because we are still so early.

